### PR TITLE
[FIX] Update summary status to completed after successful weekly summary

### DIFF
--- a/src/shiori/app/diary/application/service/diary_service.py
+++ b/src/shiori/app/diary/application/service/diary_service.py
@@ -197,6 +197,10 @@ class DiaryService:
 
             await self.upsert_diary_tag(diary=week_diary, emotion_probs=emotion_results)
 
+            await self.update_summary_status(
+                diary_meta_id=diary_meta_ids, status=SummaryStatus.completed
+            )
+
             return True
 
         except Exception as e:


### PR DESCRIPTION
### Change

- Ensures `summary_status` is updated to `completed` after emotion tagging completes successfully
- Adds fallback to `failed` status on exception

### Note

- This change improves clarity in diary status tracking and helps prevent lingering `pending` statuses after successful execution.