### PR TITLE
[FEAT] Update PermissionDependency to use HTTPBearer model

### DIFF
--- a/src/shiori/app/core/dependencies/permission.py
+++ b/src/shiori/app/core/dependencies/permission.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Type
 
 from fastapi import Request
-from fastapi.openapi.models import APIKey, APIKeyIn
+from fastapi.openapi.models import HTTPBearer
 from fastapi.security.base import SecurityBase
 
 from shiori.app.core.exceptions import BaseCustomException, UnauthorizedException
@@ -45,7 +45,7 @@ class AllowAll(BasePermission):
 class PermissionDependency(SecurityBase):
     def __init__(self, permissions: list[Type[BasePermission]]):
         self.permissions = permissions
-        self.model: APIKey = APIKey(**{"in": APIKeyIn.header}, name="Authorization")
+        self.model: HTTPBearer = HTTPBearer(bearerFormat="JWT")
         self.scheme_name = self.__class__.__name__
 
     async def __call__(self, request: Request):


### PR DESCRIPTION
## Linked Issue

close #41
<!-- `close #issue_number` will be added automatically if configured. -->
<!-- Or manually add like: close #123 -->

<br/>
<br/>

## 🏷️ Label
- [x] Feature
- [ ] Bug
- [ ] Chore

<br/>
<br/>

## ✨ Changes
Briefly describe the key changes made in this pull request.

- Added Bearer authorization support to Swagger UI  
- Implemented `PermissionDependency` with JWT bearer model integration  
<br/>

## 🔍 Additional Notes
Add any extra information, screenshots, or context that may help reviewers.

- Developers can now use the "Authorize" button in Swagger to input JWT tokens  
- Simplifies testing secured endpoints directly from the documentation  
<br/>