### PR TITLE
[FEAT] Apply optimistic concurrency control to diary upsert

### DIFF
--- a/scripts/seed_diary.py
+++ b/scripts/seed_diary.py
@@ -10,6 +10,7 @@ from shiori.app.diary.infra.repository import (
     DiaryRepositoryImpl,
     DiaryMetaRepositoryImpl,
     TagRepositoryImpl,
+    ReflectionRepositoryImpl,
 )
 
 
@@ -147,6 +148,7 @@ async def seed(user_id: int, start: datetime, end: datetime) -> None:
         diary_repo=DiaryRepositoryImpl(),
         diary_meta_repo=DiaryMetaRepositoryImpl(),
         tag_repo=TagRepositoryImpl(),
+        reflection_repo=ReflectionRepositoryImpl(),
     )
 
     d = start
@@ -162,6 +164,7 @@ async def seed(user_id: int, start: datetime, end: datetime) -> None:
             user_id=user_id,
             date=date_str,
             content=content,
+            version=1,
             title=title,
         )
 

--- a/src/shiori/app/diary/application/service/diary_service.py
+++ b/src/shiori/app/diary/application/service/diary_service.py
@@ -39,6 +39,7 @@ class DiaryService:
         self._emotion_pipeline = EmotionPipeline(model=EmotionModel())
         self._summarize_pipeline = SummarizePipeline()
 
+    @MongoTransactional()
     async def save_diary(
         self,
         *,
@@ -75,10 +76,7 @@ class DiaryService:
         DiaryMetaValidator.validate_title(title)
 
         diary_meta_vo = DiaryMetaVO(
-            user_id=user_id,
-            date=date,
-            title=title,
-            version=version,
+            user_id=user_id, date=date, title=title, version=version
         )
 
         diary_meta_id = await self._diary_meta_repo.save_diary_meta(
@@ -90,14 +88,13 @@ class DiaryService:
 
         return diary_meta_id
 
-    @MongoTransactional()
     async def upsert_diary(
         self,
         *,
         user_id: int,
         date: str,
-        version: int,
         content: ProseMirror,
+        version: Optional[int],
         title: Optional[str] = "",
     ) -> tuple[str | None, bool | None]:
 

--- a/src/shiori/app/diary/application/service/diary_service.py
+++ b/src/shiori/app/diary/application/service/diary_service.py
@@ -86,7 +86,7 @@ class DiaryService:
         )
 
         if not diary_meta_id:
-            raise ConflictDiary("DiaryMeta was updated by another transaction")
+            raise ConflictDiary
 
         return diary_meta_id
 

--- a/src/shiori/app/diary/application/service/diary_service.py
+++ b/src/shiori/app/diary/application/service/diary_service.py
@@ -69,7 +69,7 @@ class DiaryService:
         user_id: int,
         date: str,
         title: str,
-        version: int,
+        version: Optional[int],
     ) -> str | None:
 
         DiaryMetaValidator.validate_date_format(date)

--- a/src/shiori/app/diary/application/usecase/upsert_diary.py
+++ b/src/shiori/app/diary/application/usecase/upsert_diary.py
@@ -13,8 +13,8 @@ class UpsertDiary:
         *,
         user_id: int,
         date: str,
-        version: int,
         content: ProseMirror,
+        version: Optional[int],
         title: Optional[str] = "",
     ) -> tuple[str | None, bool | None]:
         diary_id, is_created = await self._diary_service.upsert_diary(

--- a/src/shiori/app/diary/application/usecase/upsert_diary.py
+++ b/src/shiori/app/diary/application/usecase/upsert_diary.py
@@ -13,11 +13,16 @@ class UpsertDiary:
         *,
         user_id: int,
         date: str,
+        version: int,
         content: ProseMirror,
         title: Optional[str] = "",
     ) -> tuple[str | None, bool | None]:
         diary_id, is_created = await self._diary_service.upsert_diary(
-            user_id=user_id, date=date, content=content, title=title
+            user_id=user_id,
+            date=date,
+            version=version,
+            content=content,
+            title=title,
         )
 
         return diary_id, is_created

--- a/src/shiori/app/diary/domain/entity/diary_meta.py
+++ b/src/shiori/app/diary/domain/entity/diary_meta.py
@@ -10,9 +10,9 @@ class DiaryMeta:
     user_id: int
     date: str
     title: str = ""
-    version: int = 1
     summary_status: SummaryStatus = SummaryStatus.pending
     is_archived: bool = False
+    version: Optional[int] = 1
     id: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -49,7 +49,7 @@ class DiaryMeta:
             user_id=self.user_id,
             date=self.date,
             title=self.title,
-            version=self.version,
+            version=self.version if self.version else 1,
             summary_status=self.summary_status,
             is_archived=self.is_archived,
         )

--- a/src/shiori/app/diary/domain/entity/diary_meta.py
+++ b/src/shiori/app/diary/domain/entity/diary_meta.py
@@ -10,6 +10,7 @@ class DiaryMeta:
     user_id: int
     date: str
     title: str = ""
+    version: int = 1
     summary_status: SummaryStatus = SummaryStatus.pending
     is_archived: bool = False
     id: Optional[str] = None
@@ -36,6 +37,7 @@ class DiaryMeta:
             date=model.date,
             title=model.title,
             summary_status=model.summary_status,
+            version=model.version,
             is_archived=model.is_archived,
             created_at=model.created_at,
             updated_at=model.updated_at,
@@ -47,6 +49,7 @@ class DiaryMeta:
             user_id=self.user_id,
             date=self.date,
             title=self.title,
+            version=self.version,
             summary_status=self.summary_status,
             is_archived=self.is_archived,
         )

--- a/src/shiori/app/diary/domain/exception/__init__.py
+++ b/src/shiori/app/diary/domain/exception/__init__.py
@@ -29,3 +29,12 @@ class SummarizeFailed(BaseCustomException):
         data: None = None,
     ):
         super().__init__(code=503, message=message, data=data)
+
+
+class ConflictDiary(BaseCustomException):
+    def __init__(
+        self,
+        message: str = "잠시 후 다시 시도해주세요.",
+        data: None = None,
+    ):
+        super().__init__(code=409, message=message, data=data)

--- a/src/shiori/app/diary/domain/repository/diary_meta.py
+++ b/src/shiori/app/diary/domain/repository/diary_meta.py
@@ -7,7 +7,7 @@ from shiori.app.diary.infra.model import SummaryStatus
 class DiaryMetaRepository(ABC):
 
     @abstractmethod
-    async def save_diary_meta(self, diary_meta: DiaryMetaVO) -> str:
+    async def save_diary_meta(self, diary_meta: DiaryMetaVO) -> str | None:
         pass
 
     @abstractmethod

--- a/src/shiori/app/diary/infra/model/diary_meta.py
+++ b/src/shiori/app/diary/infra/model/diary_meta.py
@@ -19,6 +19,7 @@ class DiaryMetaDocument(Document, MongoTimestampMixin):
 
     summary_status: SummaryStatus = SummaryStatus.pending
     is_archived: bool = False
+    version: int = 1
 
     class Settings:
         name = "diary-meta"

--- a/src/shiori/app/diary/interface/dto/request/__init__.py
+++ b/src/shiori/app/diary/interface/dto/request/__init__.py
@@ -28,7 +28,7 @@ class UpsertDiaryRequest(BaseModel):
         ],
     )
     title: Optional[str] = Field(..., examples=["오늘의 일지"])
-    version: int = Field(..., examples=[1])
+    version: Optional[int] = Field(None, examples=[1])
 
 
 class SummarizeDiaryRequest(BaseModel):

--- a/src/shiori/app/diary/interface/dto/request/__init__.py
+++ b/src/shiori/app/diary/interface/dto/request/__init__.py
@@ -28,6 +28,7 @@ class UpsertDiaryRequest(BaseModel):
         ],
     )
     title: Optional[str] = Field(..., examples=["오늘의 일지"])
+    version: int = Field(..., examples=[1])
 
 
 class SummarizeDiaryRequest(BaseModel):

--- a/src/shiori/app/diary/interface/router/diary.py
+++ b/src/shiori/app/diary/interface/router/diary.py
@@ -100,12 +100,14 @@ async def upsert_diary(
 
     content = body.content
     title = body.title
+    version = body.version
 
     user_id = request.user.id
 
     diary_id, is_created = await use_case.execute(
         date=date,
         user_id=user_id,
+        version=version,
         content=content,
         title=title,
     )

--- a/tests/app/diary/application/service/test_diary_service.py
+++ b/tests/app/diary/application/service/test_diary_service.py
@@ -143,21 +143,19 @@ async def test_save_diary_meta(
     user_id = 1
     date = "20250728"
     title = "dummy_title"
-
-    diary_meta_repository_mock.save_diary_meta.return_value = None
+    version = None
+    diary_meta_repository_mock.save_diary_meta.return_value = "1"
 
     # When
 
     response = await diary_service.save_diary_meta(
-        user_id=user_id,
-        date=date,
-        title=title,
+        user_id=user_id, date=date, title=title, version=version
     )
 
     # Then
 
     assert diary_meta_repository_mock.save_diary_meta.call_count == 1
-    assert response is None
+    assert response is "1"
 
 
 @pytest.mark.asyncio
@@ -169,6 +167,7 @@ async def test_save_diary_meta_invalid_date_format(
     user_id = 1
     date = "2025-07-28"
     title = "dummy_title"
+    version = 1
 
     diary_meta_repository_mock.save_diary_meta.return_value = None
 
@@ -176,9 +175,7 @@ async def test_save_diary_meta_invalid_date_format(
 
     with pytest.raises(NotValidDateFormat) as e:
         await diary_service.save_diary_meta(
-            user_id=user_id,
-            date=date,
-            title=title,
+            user_id=user_id, date=date, title=title, version=version
         )
 
     assert str(e.value.message) == "잘못된 날짜 형식이에요."
@@ -194,6 +191,7 @@ async def test_save_diary_meta_invalid_title(
     user_id = 1
     date = "20250728"
     title = "a" * 51
+    version = 1
 
     diary_meta_repository_mock.save_diary_meta.return_value = None
 
@@ -204,6 +202,7 @@ async def test_save_diary_meta_invalid_title(
             user_id=user_id,
             date=date,
             title=title,
+            version=version,
         )
 
     assert str(e.value.message) == "일지 제목은 50자 이내로 작성 해 주세요."
@@ -220,7 +219,7 @@ async def test_upsert_diary(
     user_id = 1
     date = "20250728"
     title = "dummy_title"
-
+    version = 1
     diary_content_dict = {
         "type": "doc",
         "content": [
@@ -246,6 +245,7 @@ async def test_upsert_diary(
         date=date,
         content=content,
         title=title,
+        version=version,
     )
 
     # Then
@@ -258,51 +258,6 @@ async def test_upsert_diary(
 
 @pytest.mark.asyncio
 @pytest.mark.mongo
-async def test_upsert_diary_raises_save_diary_meta(
-    diary_repository_mock, diary_meta_repository_mock, diary_service
-):
-    # Given
-    user_id = 1
-    date = "20250728"
-    title = "dummy_title"
-
-    diary_content_dict = {
-        "type": "doc",
-        "content": [
-            {
-                "type": "paragraph",
-                "attrs": {"textAlign": "left"},
-                "content": [
-                    {"type": "text", "text": "hello", "marks": [{"type": "bold"}]}
-                ],
-            }
-        ],
-    }
-
-    content = ProseMirror(**diary_content_dict)
-
-    diary_repository_mock.save_diary.return_value = "mock_diary_id", True
-    diary_meta_repository_mock.save_diary_meta.return_value = None
-
-    # When
-
-    diary_id, is_created = await diary_service.upsert_diary(
-        user_id=user_id,
-        date=date,
-        content=content,
-        title=title,
-    )
-
-    # Then
-
-    assert diary_repository_mock.save_diary.call_count == 0
-    assert diary_meta_repository_mock.save_diary_meta.call_count == 1
-    assert diary_id is None
-    assert is_created is None
-
-
-@pytest.mark.asyncio
-@pytest.mark.mongo
 async def test_upsert_diary_invalid_date_format(
     diary_repository_mock, diary_meta_repository_mock, diary_service
 ):
@@ -310,6 +265,7 @@ async def test_upsert_diary_invalid_date_format(
     user_id = 1
     date = "2025-07-28"
     title = "dummy_title"
+    version = 1
 
     diary_content_dict = {
         "type": "doc",
@@ -337,6 +293,7 @@ async def test_upsert_diary_invalid_date_format(
             date=date,
             content=content,
             title=title,
+            version=version,
         )
 
     assert str(e.value.message) == "잘못된 날짜 형식이에요."

--- a/tests/app/diary/application/usecase/test_upsert_diary.py
+++ b/tests/app/diary/application/usecase/test_upsert_diary.py
@@ -20,7 +20,7 @@ async def test_execute(diary_service_mock):
     user_id = 1
     date = "20250728"
     title = "dummy_title"
-
+    version = None
     diary_content_dict = {
         "type": "doc",
         "content": [
@@ -43,7 +43,7 @@ async def test_execute(diary_service_mock):
     # When
 
     diary_id, is_created = await use_case.execute(
-        user_id=user_id, date=date, content=content, title=title
+        user_id=user_id, date=date, content=content, title=title, version=version
     )
 
     # Then
@@ -51,5 +51,5 @@ async def test_execute(diary_service_mock):
     assert is_created
     assert diary_id is not None
     diary_service_mock.upsert_diary.assert_awaited_with(
-        user_id=user_id, date=date, content=content, title=title
+        user_id=user_id, date=date, content=content, title=title, version=version
     )

--- a/tests/app/diary/interface/router/test_diary.py
+++ b/tests/app/diary/interface/router/test_diary.py
@@ -60,6 +60,7 @@ async def test_upsert_diary_update(access_token_mock):
     access_token = access_token_mock
 
     date = "20250728"
+    version = 1
     content = {
         "type": "doc",
         "content": [
@@ -79,14 +80,14 @@ async def test_upsert_diary_update(access_token_mock):
         "content": content,
         "title": title,
     }
-
+    body2 = {"content": content, "title": title, "version": version}
     # When
     headers = {"Authorization": f"Bearer {access_token}"}
     async with AsyncClient(app=app, base_url=BASE_URL, headers=headers) as client:
         response = await client.post(f"/api/diary/{date}", json=body)
 
     async with AsyncClient(app=app, base_url=BASE_URL, headers=headers) as client:
-        response = await client.post(f"/api/diary/{date}", json=body)
+        response = await client.post(f"/api/diary/{date}", json=body2)
 
     # Then
     assert response.json().get("code") == 200


### PR DESCRIPTION
## Linked Issue

close #43
<!-- `close #issue_number` will be added automatically if configured. -->
<!-- Or manually add like: close #123 -->

<br/>
<br/>

## 🏷️ Label
- [x] Feature
- [ ] Bug
- [ ] Chore

<br/>
<br/>

## ✨ Changes
Briefly describe the key changes made in this pull request.

- Added version field to diary entities and API  
- Applied optimistic concurrency control with conflict handling  
- Updated logic and tests to support optional version  
<br/>

## 🔍 Additional Notes
Add any extra information, screenshots, or context that may help reviewers.

- Ensures only one update succeeds in concurrent diary upserts  
<br/>