### PR TITLE
[FEAT] Add configurable worker setting for uvicorn startup

### DIFF
--- a/src/shiori/main.py
+++ b/src/shiori/main.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import sys
 
@@ -23,19 +24,30 @@ from app.core.config import get_settings
     is_flag=True,
     default=False,
 )
-def main(env: str, debug: bool) -> None:
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Number of worker processes. Defaults to CPU count in prod.",
+)
+def main(env: str, debug: bool, workers: int | None) -> None:
 
     os.environ["ENV"] = env
     os.environ["DEBUG"] = str(debug)
 
     settings = get_settings()
 
+    if env == "dev":
+        num_workers = 1
+    else:
+        num_workers = workers or multiprocessing.cpu_count()
+
     uvicorn.run(
         app="app.server:app",
         host=settings.APP_HOST,
         port=settings.APP_PORT,
-        reload=True if env == "dev" else False,
-        workers=1,
+        reload=(env == "dev"),
+        workers=num_workers,
     )
 
 


### PR DESCRIPTION
## Linked Issue
<!-- `close #issue_number` will be added automatically if configured. -->
<!-- Or manually add like: close #123 -->

<br/>
<br/>

## 🏷️ Label
- [x] Feature
- [ ] Bug
- [ ] Chore

<br/>
<br/>

## ✨ Changes
Briefly describe the key changes made in this pull request.

- Added `--workers` CLI option to configure uvicorn worker processes  
- Default to CPU count in production when not provided  
- Fixed development mode to always use a single worker  
<br/>

## 🔍 Additional Notes
Add any extra information, screenshots, or context that may help reviewers.

- Keeps dev mode simple with `reload` enabled and one worker  
- Improves production flexibility by scaling workers to CPU count or custom input  
<br/>